### PR TITLE
feat: Vim navigation shortcuts

### DIFF
--- a/src/ChooseFolderModal.ts
+++ b/src/ChooseFolderModal.ts
@@ -111,14 +111,14 @@ export default class ChooseFolderModal extends FuzzySuggestModal<TFolder> {
       (evt.ctrlKey || evt.metaKey) &&
       (evt.key === 'k' || evt.key === 'p')
     ) {
-      // Ctrl+k and ctrl+p mapped to up arrow
+      // Ctrl/cmd+k and ctrl/cmd+p mapped to up arrow
       const upArrowEvent = new KeyboardEvent('keydown', { key: 'ArrowUp' });
       this.inputEl.dispatchEvent(upArrowEvent);
     } else if (
       (evt.ctrlKey || evt.metaKey) &&
       (evt.key === 'j' || evt.key === 'n')
     ) {
-      // Ctrl+j and ctrl+n mapped to down arrow
+      // Ctrl/cmd+j and ctrl/cmd+n mapped to down arrow
       const downArrowEvent = new KeyboardEvent('keydown', { key: 'ArrowDown' });
       this.inputEl.dispatchEvent(downArrowEvent);
     }

--- a/src/ChooseFolderModal.ts
+++ b/src/ChooseFolderModal.ts
@@ -37,7 +37,7 @@ export default class ChooseFolderModal extends FuzzySuggestModal<TFolder> {
   init() {
     const folders = new Set() as Set<TFolder>;
     const sortedFolders = [] as TFolder[];
-    let leaf = this.app.workspace.getLeaf(false);
+    const leaf = this.app.workspace.getLeaf(false);
     if (
       leaf &&
       leaf.view instanceof MarkdownView &&

--- a/src/ChooseFolderModal.ts
+++ b/src/ChooseFolderModal.ts
@@ -1,4 +1,11 @@
-import { App, FuzzySuggestModal, TFolder, Vault, MarkdownView, TFile } from 'obsidian';
+import {
+  App,
+  FuzzySuggestModal,
+  TFolder,
+  Vault,
+  MarkdownView,
+  TFile,
+} from 'obsidian';
 import CreateNoteModal from './CreateNoteModal';
 import { NewFileLocation } from './enums';
 
@@ -31,10 +38,12 @@ export default class ChooseFolderModal extends FuzzySuggestModal<TFolder> {
     const folders = new Set() as Set<TFolder>;
     const sortedFolders = [] as TFolder[];
     let leaf = this.app.workspace.getLeaf(false);
-    if (leaf &&
+    if (
+      leaf &&
       leaf.view instanceof MarkdownView &&
       leaf.view.file instanceof TFile &&
-      leaf.view.file.parent instanceof TFolder) {
+      leaf.view.file.parent instanceof TFolder
+    ) {
       // pre-select current folder
       folders.add(leaf.view.file.parent);
       sortedFolders.push(leaf.view.file.parent);
@@ -94,10 +103,18 @@ export default class ChooseFolderModal extends FuzzySuggestModal<TFolder> {
   }
 
   listenInput(evt: KeyboardEvent) {
-    if (evt.key == 'Tab') {
+    if (evt.key === 'Tab') {
       this.inputEl.value = this.findCurrentSelect()?.innerText;
-      // to disable tab selections on input
+      // Disable tab selections on input
       evt.preventDefault();
+    } else if (evt.ctrlKey && (evt.key === 'k' || evt.key === 'p')) {
+      // Ctrl+k and ctrl+p mapped to up arrow
+      const upArrowEvent = new KeyboardEvent('keydown', { key: 'ArrowUp' });
+      this.inputEl.dispatchEvent(upArrowEvent);
+    } else if (evt.ctrlKey && (evt.key === 'j' || evt.key === 'n')) {
+      // Ctrl+j and ctrl+n mapped to down arrow
+      const downArrowEvent = new KeyboardEvent('keydown', { key: 'ArrowDown' });
+      this.inputEl.dispatchEvent(downArrowEvent);
     }
   }
 

--- a/src/ChooseFolderModal.ts
+++ b/src/ChooseFolderModal.ts
@@ -107,11 +107,17 @@ export default class ChooseFolderModal extends FuzzySuggestModal<TFolder> {
       this.inputEl.value = this.findCurrentSelect()?.innerText;
       // Disable tab selections on input
       evt.preventDefault();
-    } else if (evt.ctrlKey && (evt.key === 'k' || evt.key === 'p')) {
+    } else if (
+      (evt.ctrlKey || evt.metaKey) &&
+      (evt.key === 'k' || evt.key === 'p')
+    ) {
       // Ctrl+k and ctrl+p mapped to up arrow
       const upArrowEvent = new KeyboardEvent('keydown', { key: 'ArrowUp' });
       this.inputEl.dispatchEvent(upArrowEvent);
-    } else if (evt.ctrlKey && (evt.key === 'j' || evt.key === 'n')) {
+    } else if (
+      (evt.ctrlKey || evt.metaKey) &&
+      (evt.key === 'j' || evt.key === 'n')
+    ) {
       // Ctrl+j and ctrl+n mapped to down arrow
       const downArrowEvent = new KeyboardEvent('keydown', { key: 'ArrowDown' });
       this.inputEl.dispatchEvent(downArrowEvent);


### PR DESCRIPTION
Closes #32 
Also adds `ctrl/cmd + p` and `ctrl/cmd + n` for up and down navigation, respectively.